### PR TITLE
Fixed naming issues with controller spawner 

### DIFF
--- a/franka_bringup/launch/franka.launch.py
+++ b/franka_bringup/launch/franka.launch.py
@@ -106,7 +106,7 @@ def generate_launch_description():
         ),
         Node(
             package='controller_manager',
-            executable='spawner.py',
+            executable='spawner',
             arguments=['joint_state_broadcaster'],
             output='screen',
         ),

--- a/franka_bringup/launch/gravity_compensation_example_controller.launch.py
+++ b/franka_bringup/launch/gravity_compensation_example_controller.launch.py
@@ -69,7 +69,7 @@ def generate_launch_description():
 
         Node(
             package='controller_manager',
-            executable='spawner.py',
+            executable='spawner',
             arguments=['gravity_compensation_example_controller'],
             output='screen',
         ),

--- a/franka_bringup/launch/joint_impedance_example_controller.launch.py
+++ b/franka_bringup/launch/joint_impedance_example_controller.launch.py
@@ -70,7 +70,7 @@ def generate_launch_description():
 
         Node(
             package='controller_manager',
-            executable='spawner.py',
+            executable='spawner',
             arguments=['joint_impedance_example_controller'],
             output='screen',
         ),

--- a/franka_bringup/launch/move_to_start_example_controller.launch.py
+++ b/franka_bringup/launch/move_to_start_example_controller.launch.py
@@ -70,7 +70,7 @@ def generate_launch_description():
 
         Node(
             package='controller_manager',
-            executable='spawner.py',
+            executable='spawner',
             arguments=['move_to_start_example_controller'],
             output='screen',
         ),

--- a/franka_moveit_config/launch/moveit.launch.py
+++ b/franka_moveit_config/launch/moveit.launch.py
@@ -186,7 +186,7 @@ def generate_launch_description():
     for controller in ['panda_arm_controller', 'joint_state_broadcaster']:
         load_controllers += [
             ExecuteProcess(
-                cmd=['ros2 run controller_manager spawner.py {}'.format(controller)],
+                cmd=['ros2 run controller_manager spawner {}'.format(controller)],
                 shell=True,
                 output='screen',
             )


### PR DESCRIPTION
Renamed spawner.py to spawner in all launch files as described by @YuLiHN in your issue at [franka_ros2 ](https://github.com/frankaemika/franka_ros2/issues/8) and according to [here](https://control.ros.org/master/doc/ros2_control/controller_manager/doc/userdoc.html).

Without renaming errors occur when trying to use your fork with a real robot arm.
